### PR TITLE
Fix resource not found error when create_dns_entry flag is false

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -15,5 +15,6 @@ output "load_balancer_security_group_id" {
 }
 
 output "fully_qualified_domain_name" {
-  value = "${aws_route53_record.consul_elb.fqdn}"
+  # Hack datasource error on count = 0
+  value = "${element(concat(aws_route53_record.consul_elb.*.fqdn, list("")), 0)}"
 }


### PR DESCRIPTION
Current error is

```
Error: Error running plan: 1 error(s) occurred:

* module.consul.module.consul_elb.output.fully_qualified_domain_name: Resource 'aws_route53_record.consul_elb' not found for variable 'aws_route53_record.consul_elb.fqdn'
```